### PR TITLE
Add value to Props to allow for v-model 2-way binding

### DIFF
--- a/src/SingleInput.vue
+++ b/src/SingleInput.vue
@@ -22,12 +22,12 @@ export default {
     inputClass: {
       type: Object,
       default: () => ({})
-    }
+    },
+    value: String
   },
 
   data () {
     return {
-      value: ''
     }
   }
 }

--- a/src/SingleInput.vue
+++ b/src/SingleInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <input class="input" :class="inputClass" type="text" :placeholder="placeholder" :readonly="readonly" v-model="value"/>
+  <input class="input" :class="inputClass" type="text" :placeholder="placeholder" :readonly="readonly" v-model="date"/>
 </template>
 
 <script>
@@ -28,6 +28,17 @@ export default {
 
   data () {
     return {
+    }
+  },
+  
+  computed: {
+    date: {
+      get() {
+        return this.value;
+      },
+      set(newValue) {
+        this.$emit('input', newValue);
+      }
     }
   }
 }

--- a/src/WrapperInput.vue
+++ b/src/WrapperInput.vue
@@ -1,6 +1,6 @@
 <template>
   <p class="control has-addons flatpickr" data-wrap="true" data-clickOpens="false" :class="{ [`has-addons-${alignment}`]: alignment }">
-    <input class="input" :class="inputClass" type="text" :placeholder="placeholder" :readonly="readonly" v-model="value" data-input/>
+    <input class="input" :class="inputClass" type="text" :placeholder="placeholder" :readonly="readonly" v-model="date" data-input/>
     <slot></slot>
   </p>
 </template>
@@ -35,6 +35,17 @@ export default {
 
   data () {
     return {
+    }
+  },
+
+  computed: {
+    date: {
+      get() {
+        return this.value;
+      },
+      set(newValue) {
+        this.$emit('input', newValue);
+      }
     }
   }
 }

--- a/src/WrapperInput.vue
+++ b/src/WrapperInput.vue
@@ -25,7 +25,8 @@ export default {
     inputClass: {
       type: Object,
       default: () => ({})
-    }
+    },
+    value: String
   },
 
   mounted () {
@@ -34,7 +35,6 @@ export default {
 
   data () {
     return {
-      value: ''
     }
   }
 }

--- a/src/index.vue
+++ b/src/index.vue
@@ -40,12 +40,12 @@ export default {
     placeholder: {
       type: String,
       default: 'Pick date'
-    }
+    },
+    value: String
   },
 
   data () {
     return {
-      value: '',
       datepicker: null
     }
   },

--- a/src/index.vue
+++ b/src/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :placeholder="placeholder" :inputClass="inputClass" :is="wrap ? 'WrapperInput' : 'SingleInput'" v-click-outside="closePicker">
+  <component v-model="date" :placeholder="placeholder" :inputClass="inputClass" :is="wrap ? 'WrapperInput' : 'SingleInput'" v-click-outside="closePicker">
     <slot></slot>
   </component>
 </template>
@@ -55,7 +55,7 @@ export default {
       this.datepicker = new Datepicker(this.$el, this.config, this.l10n)
       this.popupItem = this.datepicker.calendarContainer
       this.datepicker.set('onChange', (d, s) => {
-        this.$emit('input', this.value = s)
+        this.date = s;
       })
     }
   },
@@ -76,6 +76,14 @@ export default {
     },
     name () {
       return this.wrap ? 'wrapperInput' : 'singleInput'
+    },
+    date: {
+    	get(){
+    		return this.value
+    	},
+    	set(newValue){
+    		this.$emit('input', newValue)
+    	}
     }
   },
 


### PR DESCRIPTION
Currently, the value is held in `data(){}`.  
If the parent mutates the v-model value, the datepicker does not reflect the changes