### PR TITLE
Watch config option for reactive updates

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -37,12 +37,21 @@ export default {
       this.datepicker = new Datepicker(this.$el, this.config, this.l10n)
       this.popupItem = this.datepicker.calendarContainer
     }
+    this.$watch('config', this.redraw);
   },
 
   beforeDestroy () {
     if (this.datepicker && !this.static) {
       this.datepicker.destroy()
       this.datepicker = null
+    }
+  },
+  
+  methods: {
+    redraw(newConfig) {
+      this.datepicker.config = Object.assign(this.datepicker.config, newConfig)
+      this.datepicker.redraw();
+      this.datepicker.jumpToDate();
     }
   },
 


### PR DESCRIPTION
Allows you to change any of the config options programatically (for example, changing minDate & maxDate, after construction)

Blindly assigns in the new config to the datepicker.  
This replicates the behaviour of `flatpickr.set('configOption', configValue);` ( https://github.com/chmln/flatpickr/blob/master/src/flatpickr.js#L1379 )