### PR TITLE
Write function for default inputClass object in plain js

### DIFF
--- a/src/BasicInput.js
+++ b/src/BasicInput.js
@@ -6,7 +6,9 @@ export default {
     },
     inputClass: {
       type: Object,
-      default: () => ({})
+      default: function () {
+          return {}
+      }
     },
     value: String
   }


### PR DESCRIPTION
Hi there,

I'm running into problems uglifying my code with `vue-bulma-datepicker` as a dependency.
Somehow it cannot deal with the ES6 function syntax in [`BasicInput.js`](https://github.com/vue-bulma/datepicker/blob/master/src/BasicInput.js#L9)

I'm using Laravel-mix and installed all appropriate loaders, however I still get this message:
```
ERROR  Failed to compile with 1 errors                                                                                                                                     13:53:40

error

/js/app.e759651324a0da6e9a5a.js from UglifyJs
Unexpected token: punc ()) [./~/vue-bulma-datepicker/src/BasicInput.js:9,0][/js/app.e759651324a0da6e9a5a.js:38950,16]
```

I know it looks ugly, but the function in plain js syntax works..