### PR TITLE
Allow inputClass prop type to be either object or array

### DIFF
--- a/src/BasicInput.js
+++ b/src/BasicInput.js
@@ -5,7 +5,7 @@ export default {
       default: 'Pick date'
     },
     inputClass: {
-      type: Object,
+      type: [Object, Array],
       default: () => ({})
     },
     value: String


### PR DESCRIPTION
I updated the component prop validation to adhere to the Vue documentation regarding the `class` binding: https://vuejs.org/v2/guide/class-and-style.html#Array-Syntax

Related issue: #63 