### PR TITLE
Reset datepicker if falsy value is passed

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -58,8 +58,12 @@ export default {
       this.datepicker.redraw()
       this.datepicker.jumpToDate()
     },
-    setDate (newDate, oldDate) {
-      newDate && this.datepicker.setDate(newDate)
+    setDate (newDate) {
+      if (newDate) {
+        this.datepicker.setDate(newDate)
+      } else {
+        this.datepicker.clear()
+      }
     },
     dateUpdated (selectedDates, dateStr) {
       this.date = dateStr


### PR DESCRIPTION
The current behaviour is to only update the datepicker if the new value is truthy. I think it makes a lot of sense to clear the datepicker if a falsy value is passed.